### PR TITLE
Add user authentication

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,4 @@ config :delve, DelveWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+config :bcrypt_elixir, :log_rounds, 3

--- a/lib/delve/auth.ex
+++ b/lib/delve/auth.ex
@@ -1,0 +1,104 @@
+defmodule Delve.Auth do
+  @moduledoc """
+  The Auth context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Delve.Repo
+
+  alias Delve.Auth.User
+
+  @doc """
+  Returns the list of users.
+
+  ## Examples
+
+      iex> list_users()
+      [%User{}, ...]
+
+  """
+  def list_users do
+    Repo.all(User)
+  end
+
+  @doc """
+  Gets a single user.
+
+  Raises `Ecto.NoResultsError` if the User does not exist.
+
+  ## Examples
+
+      iex> get_user!(123)
+      %User{}
+
+      iex> get_user!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_user!(id), do: Repo.get!(User, id)
+
+  @doc """
+  Creates a user.
+
+  ## Examples
+
+      iex> create_user(%{field: value})
+      {:ok, %User{}}
+
+      iex> create_user(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_user(attrs \\ %{}) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a user.
+
+  ## Examples
+
+      iex> update_user(user, %{field: new_value})
+      {:ok, %User{}}
+
+      iex> update_user(user, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a User.
+
+  ## Examples
+
+      iex> delete_user(user)
+      {:ok, %User{}}
+
+      iex> delete_user(user)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_user(%User{} = user) do
+    Repo.delete(user)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking user changes.
+
+  ## Examples
+
+      iex> change_user(user)
+      %Ecto.Changeset{source: %User{}}
+
+  """
+  def change_user(%User{} = user) do
+    User.changeset(user, %{})
+  end
+end

--- a/lib/delve/auth.ex
+++ b/lib/delve/auth.ex
@@ -101,4 +101,27 @@ defmodule Delve.Auth do
   def change_user(%User{} = user) do
     User.changeset(user, %{})
   end
+
+  @doc """
+  Attempts to validate an email/password combination, returning {:error, message} or
+  {:ok, matching_user}
+  """
+  def authenticate_user(email, password) do
+    query = from(u in User, where: u.email == ^email)
+    query |> Repo.one() |> verify_password(password)
+  end
+
+  defp verify_password(nil, _) do
+    # dummy check to thwart timing attacks
+    Bcrypt.no_user_verify()
+    {:error, "Wrong email or password"}
+  end
+
+  defp verify_password(user, password) do
+    if Bcrypt.verify_pass(password, user.password_hash) do
+      {:ok, user}
+    else
+      {:error, "Wrong email or password"}
+    end
+  end
 end

--- a/lib/delve/auth/user.ex
+++ b/lib/delve/auth/user.ex
@@ -18,6 +18,7 @@ defmodule Delve.Auth.User do
     |> validate_required([:email, :username, :password])
     |> unique_constraint(:email)
     |> unique_constraint(:username)
+    |> put_password_hash()
   end
 
   defp put_password_hash(%Ecto.Changeset{valid?: true, changes: %{password: password}} = changeset) do

--- a/lib/delve/auth/user.ex
+++ b/lib/delve/auth/user.ex
@@ -5,6 +5,8 @@ defmodule Delve.Auth.User do
   schema "users" do
     field :email, :string
     field :username, :string
+    field :password, :string, virtual: true
+    field :password_hash, :string
 
     timestamps()
   end
@@ -12,9 +14,17 @@ defmodule Delve.Auth.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:email, :username])
-    |> validate_required([:email, :username])
+    |> cast(attrs, [:email, :username, :password])
+    |> validate_required([:email, :username, :password])
     |> unique_constraint(:email)
     |> unique_constraint(:username)
+  end
+
+  defp put_password_hash(%Ecto.Changeset{valid?: true, changes: %{password: password}} = changeset) do
+    change(changeset, password_hash: Bcrypt.hash_pwd_salt(password))
+  end
+
+  defp put_password_hash(changeset) do
+    changeset
   end
 end

--- a/lib/delve/auth/user.ex
+++ b/lib/delve/auth/user.ex
@@ -1,0 +1,20 @@
+defmodule Delve.Auth.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :email, :string
+    field :username, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:email, :username])
+    |> validate_required([:email, :username])
+    |> unique_constraint(:email)
+    |> unique_constraint(:username)
+  end
+end

--- a/lib/delve_web/controllers/fallback_controller.ex
+++ b/lib/delve_web/controllers/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule DelveWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use DelveWeb, :controller
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(DelveWeb.ErrorView)
+    |> render(:"404")
+  end
+
+  def call(conn, {:error, %Ecto.Changeset{}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(DelveWeb.ErrorView)
+    |> render(:"422")
+  end
+end

--- a/lib/delve_web/controllers/user_controller.ex
+++ b/lib/delve_web/controllers/user_controller.ex
@@ -40,4 +40,20 @@ defmodule DelveWeb.UserController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  def sign_in(conn, %{"email" => email, "password" => password}) do
+    case Auth.authenticate_user(email, password) do
+      {:ok, user} ->
+        conn
+        |> put_status(:ok)
+        |> put_view(DelveWeb.UserView)
+        |> render("sign_in.json", user: user)
+
+      {:error, message} ->
+        conn
+        |> put_status(:unauthorized)
+        |> put_view(DelveWeb.ErrorView)
+        |> render("401.json", message: message)
+    end
+  end
 end

--- a/lib/delve_web/controllers/user_controller.ex
+++ b/lib/delve_web/controllers/user_controller.ex
@@ -1,0 +1,43 @@
+defmodule DelveWeb.UserController do
+  use DelveWeb, :controller
+
+  alias Delve.Auth
+  alias Delve.Auth.User
+
+  action_fallback DelveWeb.FallbackController
+
+  def index(conn, _params) do
+    users = Auth.list_users()
+    render(conn, "index.json", users: users)
+  end
+
+  def create(conn, %{"user" => user_params}) do
+    with {:ok, %User{} = user} <- Auth.create_user(user_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.user_path(conn, :show, user))
+      |> render("show.json", user: user)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    user = Auth.get_user!(id)
+    render(conn, "show.json", user: user)
+  end
+
+  def update(conn, %{"id" => id, "user" => user_params}) do
+    user = Auth.get_user!(id)
+
+    with {:ok, %User{} = user} <- Auth.update_user(user, user_params) do
+      render(conn, "show.json", user: user)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    user = Auth.get_user!(id)
+
+    with {:ok, %User{}} <- Auth.delete_user(user) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/delve_web/router.ex
+++ b/lib/delve_web/router.ex
@@ -8,5 +8,6 @@ defmodule DelveWeb.Router do
   scope "/api", DelveWeb do
     pipe_through :api
     resources "/users", UserController, except: [:new, :edit]
+    post "/users/sign_in", UserController, :sign_in
   end
 end

--- a/lib/delve_web/router.ex
+++ b/lib/delve_web/router.ex
@@ -7,5 +7,6 @@ defmodule DelveWeb.Router do
 
   scope "/api", DelveWeb do
     pipe_through :api
+    resources "/users", UserController, except: [:new, :edit]
   end
 end

--- a/lib/delve_web/views/changeset_view.ex
+++ b/lib/delve_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule DelveWeb.ChangesetView do
+  use DelveWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `DelveWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/delve_web/views/error_view.ex
+++ b/lib/delve_web/views/error_view.ex
@@ -13,4 +13,8 @@ defmodule DelveWeb.ErrorView do
   def template_not_found(template, _assigns) do
     %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
   end
+
+  def render("401.json", %{message: message}) do
+    %{errors: %{detail: message}}
+  end
 end

--- a/lib/delve_web/views/user_view.ex
+++ b/lib/delve_web/views/user_view.ex
@@ -1,0 +1,16 @@
+defmodule DelveWeb.UserView do
+  use DelveWeb, :view
+  alias DelveWeb.UserView
+
+  def render("index.json", %{users: users}) do
+    %{data: render_many(users, UserView, "user.json")}
+  end
+
+  def render("show.json", %{user: user}) do
+    %{data: render_one(user, UserView, "user.json")}
+  end
+
+  def render("user.json", %{user: user}) do
+    %{id: user.id, email: user.email, username: user.username}
+  end
+end

--- a/lib/delve_web/views/user_view.ex
+++ b/lib/delve_web/views/user_view.ex
@@ -13,4 +13,9 @@ defmodule DelveWeb.UserView do
   def render("user.json", %{user: user}) do
     %{id: user.id, email: user.email, username: user.username}
   end
+
+  def render("sign_in.json", %{user: user}) do
+    user_data = %{ id: user.id, email: user.email }
+    %{data: %{ user: user_data }}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule Delve.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
+      {:bcrypt_elixir, "~> 2.0"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{
+  "bcrypt_elixir": {:hex, :bcrypt_elixir, "2.0.3", "64e0792d5b5064391927bf3b8e436994cafd18ca2d2b76dea5c76e0adcf66b7c", [:make, :mix], [{:comeonin, "~> 5.1", [hex: :comeonin, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "comeonin": {:hex, :comeonin, "5.1.2", "fbbbbbfcf0f0e9900c0336d16c8d462edf838ba1759577e29cc5fbd7c28a4540", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
@@ -6,6 +8,7 @@
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.1.7", "fa21d06ef56cdc2fdaa62574e8c3ba34a2751d44ea34c30bc65f0728421043e5", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ecto_sql": {:hex, :ecto_sql, "3.1.6", "1e80e30d16138a729c717f73dcb938590bcdb3a4502f3012414d0cbb261045d8", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.1.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.9.1", [hex: :mariaex, repo: "hexpm", optional: true]}, {:myxql, "~> 0.2.0", [hex: :myxql, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.14.0 or ~> 0.15.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.17.0", "abe21542c831887a2b16f4c94556db9c421ab301aee417b7c4fbde7fbdbe01ec", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},

--- a/priv/repo/migrations/20190906013957_create_users.exs
+++ b/priv/repo/migrations/20190906013957_create_users.exs
@@ -5,7 +5,7 @@ defmodule Delve.Repo.Migrations.CreateUsers do
     create table(:users) do
       add :email, :string, null: false
       add :username, :string, null: false
-      add :password_hash, :string, null: false
+      add :password_hash, :string
 
       timestamps()
     end

--- a/priv/repo/migrations/20190906013957_create_users.exs
+++ b/priv/repo/migrations/20190906013957_create_users.exs
@@ -1,0 +1,16 @@
+defmodule Delve.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string, null: false
+      add :username, :string, null: false
+      add :password_hash, :string, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:users, [:email])
+    create unique_index(:users, [:username])
+  end
+end

--- a/test/delve/auth_test.exs
+++ b/test/delve/auth_test.exs
@@ -33,6 +33,7 @@ defmodule Delve.AuthTest do
       assert {:ok, %User{} = user} = Auth.create_user(@valid_attrs)
       assert user.email == "some email"
       assert user.username == "some username"
+      assert Bcrypt.verify_pass("fake password", user.password_hash)
     end
 
     test "create_user/1 with invalid data returns error changeset" do
@@ -44,12 +45,15 @@ defmodule Delve.AuthTest do
       assert {:ok, %User{} = user} = Auth.update_user(user, @update_attrs)
       assert user.email == "some updated email"
       assert user.username == "some updated username"
+      assert user.password_hash != nil
+      assert Bcrypt.verify_pass("new password", user.password_hash)
     end
 
     test "update_user/2 with invalid data returns error changeset" do
       user = user_fixture()
       assert {:error, %Ecto.Changeset{}} = Auth.update_user(user, @invalid_attrs)
       assert %User{user | password: nil} == Auth.get_user!(user.id)
+      assert Bcrypt.verify_pass("fake password", user.password_hash)
     end
 
     test "delete_user/1 deletes the user" do

--- a/test/delve/auth_test.exs
+++ b/test/delve/auth_test.exs
@@ -6,9 +6,9 @@ defmodule Delve.AuthTest do
   describe "users" do
     alias Delve.Auth.User
 
-    @valid_attrs %{email: "some email", username: "some username"}
-    @update_attrs %{email: "some updated email", username: "some updated username"}
-    @invalid_attrs %{email: nil, username: nil}
+    @valid_attrs %{email: "some email", username: "some username", password: "fake password"}
+    @update_attrs %{email: "some updated email", username: "some updated username", password: "new password"}
+    @invalid_attrs %{email: nil, username: nil, password: nil}
 
     def user_fixture(attrs \\ %{}) do
       {:ok, user} =
@@ -21,12 +21,12 @@ defmodule Delve.AuthTest do
 
     test "list_users/0 returns all users" do
       user = user_fixture()
-      assert Auth.list_users() == [user]
+      assert Auth.list_users() == [%User{user | password: nil}]
     end
 
     test "get_user!/1 returns the user with given id" do
       user = user_fixture()
-      assert Auth.get_user!(user.id) == user
+      assert Auth.get_user!(user.id) == %User{user | password: nil}
     end
 
     test "create_user/1 with valid data creates a user" do
@@ -49,7 +49,7 @@ defmodule Delve.AuthTest do
     test "update_user/2 with invalid data returns error changeset" do
       user = user_fixture()
       assert {:error, %Ecto.Changeset{}} = Auth.update_user(user, @invalid_attrs)
-      assert user == Auth.get_user!(user.id)
+      assert %User{user | password: nil} == Auth.get_user!(user.id)
     end
 
     test "delete_user/1 deletes the user" do

--- a/test/delve/auth_test.exs
+++ b/test/delve/auth_test.exs
@@ -66,5 +66,21 @@ defmodule Delve.AuthTest do
       user = user_fixture()
       assert %Ecto.Changeset{} = Auth.change_user(user)
     end
+
+    test "authenticate_user/2 with with correct email/password" do
+      user = user_fixture()
+      assert {:ok, authenticated_user} = Auth.authenticate_user("some email", "fake password")
+      assert authenticated_user.id == user.id
+    end
+
+    test "authenticate_user/2 with real user and wrong password" do
+      user_fixture()
+      assert {:error, "Wrong email or password"} == Auth.authenticate_user("some email", "wrong password")
+    end
+
+    test "authenticate_user/2 with unrecognized user" do
+      user_fixture()
+      assert {:error, "Wrong email or password"} == Auth.authenticate_user("missing email", "fake password")
+    end
   end
 end

--- a/test/delve/auth_test.exs
+++ b/test/delve/auth_test.exs
@@ -1,0 +1,66 @@
+defmodule Delve.AuthTest do
+  use Delve.DataCase
+
+  alias Delve.Auth
+
+  describe "users" do
+    alias Delve.Auth.User
+
+    @valid_attrs %{email: "some email", username: "some username"}
+    @update_attrs %{email: "some updated email", username: "some updated username"}
+    @invalid_attrs %{email: nil, username: nil}
+
+    def user_fixture(attrs \\ %{}) do
+      {:ok, user} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Auth.create_user()
+
+      user
+    end
+
+    test "list_users/0 returns all users" do
+      user = user_fixture()
+      assert Auth.list_users() == [user]
+    end
+
+    test "get_user!/1 returns the user with given id" do
+      user = user_fixture()
+      assert Auth.get_user!(user.id) == user
+    end
+
+    test "create_user/1 with valid data creates a user" do
+      assert {:ok, %User{} = user} = Auth.create_user(@valid_attrs)
+      assert user.email == "some email"
+      assert user.username == "some username"
+    end
+
+    test "create_user/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Auth.create_user(@invalid_attrs)
+    end
+
+    test "update_user/2 with valid data updates the user" do
+      user = user_fixture()
+      assert {:ok, %User{} = user} = Auth.update_user(user, @update_attrs)
+      assert user.email == "some updated email"
+      assert user.username == "some updated username"
+    end
+
+    test "update_user/2 with invalid data returns error changeset" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = Auth.update_user(user, @invalid_attrs)
+      assert user == Auth.get_user!(user.id)
+    end
+
+    test "delete_user/1 deletes the user" do
+      user = user_fixture()
+      assert {:ok, %User{}} = Auth.delete_user(user)
+      assert_raise Ecto.NoResultsError, fn -> Auth.get_user!(user.id) end
+    end
+
+    test "change_user/1 returns a user changeset" do
+      user = user_fixture()
+      assert %Ecto.Changeset{} = Auth.change_user(user)
+    end
+  end
+end

--- a/test/delve_web/controllers/user_controller_test.exs
+++ b/test/delve_web/controllers/user_controller_test.exs
@@ -87,6 +87,33 @@ defmodule DelveWeb.UserControllerTest do
     end
   end
 
+  describe "sign-in user" do
+    setup [:create_user]
+    
+    test "succeeds with good credentials", %{conn: conn, user: user} do
+      params = %{email: "some email", password: "some password"}
+      conn = post(conn, Routes.user_path(conn, :sign_in), params)
+
+      expected_user_data = %{"id" => user.id, "email" => user.email}
+      expected_response_data = %{"data" => %{ "user" => expected_user_data}}
+      assert json_response(conn, 200) == expected_response_data
+    end
+
+    test "fails with bad password", %{conn: conn} do
+      params = %{email: "some email", password: "wrong password"}
+      conn = post(conn, Routes.user_path(conn, :sign_in), params)
+      assert response(conn, 401)
+      assert json_response(conn, 401)["errors"]["detail"] =~ ~r/password/
+    end
+
+    test "fails with unrecognized user", %{conn: conn} do
+      params = %{email: "wrong email", password: "some password"}
+      conn = post(conn, Routes.user_path(conn, :sign_in), params)
+      assert response(conn, 401)
+      assert json_response(conn, 401)["errors"]["detail"] =~ ~r/password/
+    end
+  end
+
   defp create_user(_) do
     user = fixture(:user)
     {:ok, user: user}

--- a/test/delve_web/controllers/user_controller_test.exs
+++ b/test/delve_web/controllers/user_controller_test.exs
@@ -1,0 +1,94 @@
+defmodule DelveWeb.UserControllerTest do
+  use DelveWeb.ConnCase
+
+  alias Delve.Auth
+  alias Delve.Auth.User
+
+  @create_attrs %{
+    email: "some email",
+    password: "some password",
+    username: "some username"
+  }
+  @update_attrs %{
+    email: "some updated email",
+    password: "some updated password",
+    username: "some updated username"
+  }
+  @invalid_attrs %{email: nil, password: nil, username: nil}
+
+  def fixture(:user) do
+    {:ok, user} = Auth.create_user(@create_attrs)
+    user
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all users", %{conn: conn} do
+      conn = get(conn, Routes.user_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create user" do
+    test "renders user when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.user_path(conn, :create), user: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.user_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "email" => "some email",
+               "username" => "some username"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.user_path(conn, :create), user: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update user" do
+    setup [:create_user]
+
+    test "renders user when data is valid", %{conn: conn, user: %User{id: id} = user} do
+      conn = put(conn, Routes.user_path(conn, :update, user), user: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.user_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "email" => "some updated email",
+               "username" => "some updated username"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, user: user} do
+      conn = put(conn, Routes.user_path(conn, :update, user), user: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete user" do
+    setup [:create_user]
+
+    test "deletes chosen user", %{conn: conn, user: user} do
+      conn = delete(conn, Routes.user_path(conn, :delete, user))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.user_path(conn, :show, user))
+      end
+    end
+  end
+
+  defp create_user(_) do
+    user = fixture(:user)
+    {:ok, user: user}
+  end
+end


### PR DESCRIPTION
Add user model/api and authentication layer. Mostly following along with https://lobotuerto.com/blog/building-a-json-api-in-elixir-with-phoenix/, with tweaks.

Users have email, username, and password_hash to track (but not is_active - we won't include a sign-up flow initially). We're building it as a pure-json api, but will eventually include a single static html page to render the frontend SPA from a cdn - this affects sign-in flow/design.